### PR TITLE
Use websocket first then fallback to polling

### DIFF
--- a/src/scripts/socket.js
+++ b/src/scripts/socket.js
@@ -36,7 +36,7 @@ function startListenToSocket() {
         global.pokemonSettings = {};
     }
 
-    var socket = io.connect(global.config.websocket + "/event");
+    var socket = io.connect(global.config.websocket + "/event", {transports: ['websocket', 'polling']});
     global.ws = socket;
 
     socket.on('connect', () => {


### PR DESCRIPTION
By default, Socket.IO uses polling. As websocket is more efficient, we may want to switch to it through the option.
